### PR TITLE
Add ability to trigger 'run' workflow manually

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -1,6 +1,7 @@
 name: run
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '5 13 * * *' # 9:05AM EST every day
 


### PR DESCRIPTION
## Motivation

Need to be able to run this workflow manually 

## Changes

Adds the `workflow_dispatch` option, see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch

## Testing Instructions

Will try it in the UI
